### PR TITLE
Upgrade nuget package reference from Humanizr to Humanizr.Core v2.0.0

### DIFF
--- a/Dates.Recurring/Dates.Recurring.csproj
+++ b/Dates.Recurring/Dates.Recurring.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Humanizer, Version=1.37.7.0, Culture=neutral, PublicKeyToken=979442b78dfc278e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Humanizer.1.37.7\lib\portable-win+net40+sl50+wp8+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Humanizer.dll</HintPath>
+    <Reference Include="Humanizer, Version=2.0.0.0, Culture=neutral, PublicKeyToken=979442b78dfc278e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Humanizer.Core.2.0.0\lib\dotnet\Humanizer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Dates.Recurring/packages.config
+++ b/Dates.Recurring/packages.config
@@ -1,4 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Humanizer" version="1.37.7" targetFramework="net45" />
+  <package id="Humanizer.Core" version="2.0.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.0.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This update removes the Nuget package for Humanizr 1.37.7 (with all its localization) and adds the package Humanizr.Core 2.0.0 along with its dependencies.

I ran the NUnit tests and everything still passes.