### PR TITLE
Added IRecurring interface, Builder methods for DateTime & tests

### DIFF
--- a/Dates.Recurring.Tests/DailyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/DailyRecurrenceTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dates.Recurring.Type;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,7 +15,7 @@ namespace Dates.Recurring.Tests
         public void Daily_EveryDay()
         {
             // Arrange.
-            var daily = Recurs
+            IRecurring daily = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(1)
                 .Days()
@@ -34,7 +35,7 @@ namespace Dates.Recurring.Tests
         public void Daily_EveryThirdDay()
         {
             // Arrange.
-            var daily = Recurs
+            IRecurring daily = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(3)
                 .Days()

--- a/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dates.Recurring.Type;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,7 +15,7 @@ namespace Dates.Recurring.Tests
         public void Monthly_EveryMonth()
         {
             // Arrange.
-            var monthly = Recurs
+            IRecurring monthly = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(1)
                 .Months()
@@ -38,7 +39,7 @@ namespace Dates.Recurring.Tests
         public void Monthly_EveryThirdMonth()
         {
             // Arrange.
-            var monthly = Recurs
+            IRecurring monthly = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(3)
                 .Months()
@@ -63,7 +64,7 @@ namespace Dates.Recurring.Tests
         public void Monthly_EveryMonth_DifferentDaysInMonths()
         {
             // Arrange.
-            var monthly = Recurs
+            IRecurring monthly = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(1)
                 .Months()

--- a/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Dates.Recurring.Type;
 
 namespace Dates.Recurring.Tests
 {
@@ -13,7 +14,7 @@ namespace Dates.Recurring.Tests
         public void Weekly_EveryWeek()
         {
             // Arrange.
-            var weekly = Recurs
+            IRecurring weekly = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(1)
                 .Weeks()
@@ -35,7 +36,7 @@ namespace Dates.Recurring.Tests
         public void Weekly_EveryThirdWeek()
         {
             // Arrange.
-            var weekly = Recurs
+            IRecurring weekly = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(3)
                 .Weeks()

--- a/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
@@ -18,7 +18,7 @@ namespace Dates.Recurring.Tests
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(1)
                 .Weeks()
-                .On(Day.TUESDAY | Day.FRIDAY)
+                .OnDays(Day.TUESDAY | Day.FRIDAY)
                 .Ending(new DateTime(2015, 2, 19))
                 .Build();
 
@@ -40,7 +40,7 @@ namespace Dates.Recurring.Tests
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(3)
                 .Weeks()
-                .On(Day.TUESDAY | Day.FRIDAY)
+                .OnDays(Day.TUESDAY | Day.FRIDAY)
                 .Ending(new DateTime(2015, 2, 19))
                 .Build();
 
@@ -54,6 +54,31 @@ namespace Dates.Recurring.Tests
             Assert.Equal(new DateTime(2015, 2, 10), weekly.Next(new DateTime(2015, 1, 24)));
             Assert.Equal(new DateTime(2015, 2, 10), weekly.Next(new DateTime(2015, 1, 27)));
             Assert.Equal(new DateTime(2015, 2, 13), weekly.Next(new DateTime(2015, 2, 10)));
+        }
+
+        [Fact]
+        public void Weekly_EveryWeek_TwoDaysAfterDateTime()
+        {
+            // Arrange.
+            DateTime startDate = new DateTime(2015, 1, 1);
+
+            IRecurring weekly = Recurs
+                .Starting(startDate)
+                .Every(1)
+                .Weeks()
+                .OnDay(startDate.AddDays(2).DayOfWeek)
+                .Ending(new DateTime(2015, 2, 19))
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2015, 1, 3), weekly.Next(new DateTime(2014, 1, 1)));
+            Assert.Equal(new DateTime(2015, 1, 3), weekly.Next(new DateTime(2015, 1, 2)));
+            Assert.Equal(new DateTime(2015, 1, 10), weekly.Next(new DateTime(2015, 1, 6)));
+            Assert.Equal(new DateTime(2015, 1, 10), weekly.Next(new DateTime(2015, 1, 9)));
+            Assert.Equal(new DateTime(2015, 1, 17), weekly.Next(new DateTime(2015, 1, 13)));
+            Assert.Null(weekly.Next(new DateTime(2015, 2, 19)));
         }
     }
 }

--- a/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
@@ -66,7 +66,7 @@ namespace Dates.Recurring.Tests
                 .Starting(startDate)
                 .Every(1)
                 .Weeks()
-                .OnDay(startDate.AddDays(2).DayOfWeek)
+                .OnDay(DayOfWeek.Saturday)
                 .Ending(new DateTime(2015, 2, 19))
                 .Build();
 

--- a/Dates.Recurring.Tests/YearlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/YearlyRecurrenceTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Dates.Recurring.Type;
 
 namespace Dates.Recurring.Tests
 {
@@ -14,7 +15,7 @@ namespace Dates.Recurring.Tests
         public void Yearly_EveryYear()
         {
             // Arrange.
-            var yearly = Recurs
+            IRecurring yearly = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(1)
                 .Years()
@@ -48,7 +49,7 @@ namespace Dates.Recurring.Tests
         public void Yearly_EveryThirdYear()
         {
             // Arrange.
-            var yearly = Recurs
+            IRecurring yearly = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(3)
                 .Years()
@@ -84,7 +85,7 @@ namespace Dates.Recurring.Tests
         public void Yearly_EveryYear_DifferentDaysInMonth()
         {
             // Arrange.
-            var yearly = Recurs
+            IRecurring yearly = Recurs
                 .Starting(new DateTime(2015, 1, 1))
                 .Every(1)
                 .Years()

--- a/Dates.Recurring.Tests/YearlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/YearlyRecurrenceTests.cs
@@ -105,6 +105,36 @@ namespace Dates.Recurring.Tests
             Assert.Null(yearly.Next(new DateTime(2020, 1, 1)));
         }
 
+        [Fact]
+        public void Yearly_EveryYear_TwoMonthsAfterDateTime()
+        {
+            // Arrange.
+            var startDate = new DateTime(2015, 1, 1);
+
+            IRecurring yearly = Recurs
+                .Starting(startDate)
+                .Every(1)
+                .Years()
+                .OnDay(24)
+                .OnMonth(startDate.AddMonths(2))
+                .Ending(new DateTime(2020, 1, 1))
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2015, 3, 24), yearly.Next(new DateTime(2014, 1, 1)));
+            Assert.Equal(new DateTime(2015, 3, 24), yearly.Next(new DateTime(2015, 1, 1)));
+            Assert.Equal(new DateTime(2015, 3, 24), yearly.Next(new DateTime(2015, 1, 23)));
+            Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 3, 24)));
+            Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 3, 25)));
+            Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 10, 1)));
+            Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 10, 23)));
+            Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 10, 24)));
+            Assert.Equal(new DateTime(2017, 3, 24), yearly.Next(new DateTime(2016, 3, 24)));
+            Assert.Equal(new DateTime(2017, 3, 24), yearly.Next(new DateTime(2016, 4, 24)));
+            Assert.Null(yearly.Next(new DateTime(2020, 1, 1)));
+        }
     }
 }
 

--- a/Dates.Recurring/Builders/WeeksBuilder.cs
+++ b/Dates.Recurring/Builders/WeeksBuilder.cs
@@ -27,9 +27,38 @@ namespace Dates.Recurring.Builders
             return this;
         }
 
-        public WeeksBuilder On(Day days)
+        public WeeksBuilder OnDays(Day days)
         {
             _days = days;
+            return this;
+        }
+
+        public WeeksBuilder OnDay(DayOfWeek day)
+        {
+            switch(day)
+            {
+                case DayOfWeek.Sunday:
+                    _days = Day.SUNDAY;
+                    break;
+                case DayOfWeek.Monday:
+                    _days = Day.MONDAY;
+                    break;
+                case DayOfWeek.Tuesday:
+                    _days = Day.TUESDAY;
+                    break;
+                case DayOfWeek.Wednesday:
+                    _days = Day.WEDNESDAY;
+                    break;
+                case DayOfWeek.Thursday:
+                    _days = Day.THURSDAY;
+                    break;
+                case DayOfWeek.Friday:
+                    _days = Day.FRIDAY;
+                    break;
+                case DayOfWeek.Saturday:
+                    _days = Day.SATURDAY;
+                    break;
+            }
             return this;
         }
 

--- a/Dates.Recurring/Builders/YearsBuilder.cs
+++ b/Dates.Recurring/Builders/YearsBuilder.cs
@@ -39,6 +39,50 @@ namespace Dates.Recurring.Builders
             return this;
         }
 
+        public YearsBuilder OnMonth(DateTime dateTime)
+        {
+            switch(dateTime.Month)
+            {
+                case 1:
+                    _month = Month.JANUARY;
+                    break;
+                case 2:
+                    _month = Month.FEBRUARY;
+                    break;
+                case 3:
+                    _month = Month.MARCH;
+                    break;
+                case 4:
+                    _month = Month.APRIL;
+                    break;
+                case 5:
+                    _month = Month.MAY;
+                    break;
+                case 6:
+                    _month = Month.JUNE;
+                    break;
+                case 7:
+                    _month = Month.JULY;
+                    break;
+                case 8:
+                    _month = Month.AUGUST;
+                    break;
+                case 9:
+                    _month = Month.SEPTEMBER;
+                    break;
+                case 10:
+                    _month = Month.OCTOBER;
+                    break;
+                case 11:
+                    _month = Month.NOVEMBER;
+                    break;
+                case 12:
+                    _month = Month.DECEMBER;
+                    break;
+            }
+            return this;
+        }
+
         public Yearly Build()
         {
             return new Yearly(_skipYears, _dayOfMonth, _month, _starting, _ending);

--- a/Dates.Recurring/Dates.Recurring.csproj
+++ b/Dates.Recurring/Dates.Recurring.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Recurs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Type\Daily.cs" />
+    <Compile Include="Type\IRecurring.cs" />
     <Compile Include="Type\Monthly.cs" />
     <Compile Include="Type\RecurrenceType.cs" />
     <Compile Include="Type\Weekly.cs" />

--- a/Dates.Recurring/Type/IRecurring.cs
+++ b/Dates.Recurring/Type/IRecurring.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dates.Recurring.Type
+{
+    public interface IRecurring
+    {
+        DateTime? Next(DateTime after);
+    }
+}

--- a/Dates.Recurring/Type/RecurrenceType.cs
+++ b/Dates.Recurring/Type/RecurrenceType.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Dates.Recurring.Type
 {
-    public abstract class RecurrenceType
+    public abstract class RecurrenceType : IRecurring
     {
         protected int X { get; set; }
         protected DateTime Starting { get; set; }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var weekly = Recurs
     .Starting(new DateTime(2015, 1, 1))
     .Every(1)
     .Weeks()
-    .On(Day.TUESDAY | Day.FRIDAY)
+    .OnDays(Day.TUESDAY | Day.FRIDAY)
     .Ending(new DateTime(2015, 2, 19))
     .Build();
 


### PR DESCRIPTION
I added an IRecurring interface to allow me to build up a `RecurrenceType` without knowing what type it is and still be able to call `Next(DateTime)` on it.

This could be used when starting with an `EveryBuilder` but then calling `Months()` or `Weeks()` depending on some other variable. Then you get a LINQ-y syntax because you don't have to declare the instance type to be able to call `Next` after calling `Build`.

I also added a method `OnDay(DayOfWeek day)` to the `WeeksBuilder` and `OnMonth(DateTime dateTime)` to the `YearsBuilder` to give more integration with `DateTime` objects, which is what I'm finding I have on hand when I'm using this library.

Finally I changed the `On(Day day)` method for the `WeeksBuilder` to be `OnDays` which brings it in line with the naming conventions for the other Builders.

I updated the tests accordingly.