### PR TITLE
Adds configurable FirstDayOfWeek property for the Weekly recurrence pattern

### DIFF
--- a/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
@@ -80,5 +80,70 @@ namespace Dates.Recurring.Tests
             Assert.Equal(new DateTime(2015, 1, 17), weekly.Next(new DateTime(2015, 1, 13)));
             Assert.Null(weekly.Next(new DateTime(2015, 2, 19)));
         }
+
+        [Fact]
+        public void Weekly_Every2Weeks_SatSun()
+        {
+            // Arrange.
+            DateTime startDate = new DateTime(2018, 2, 22);
+
+            IRecurring weekly = Recurs
+                .Starting(startDate)
+                .Every(2)   
+                .Weeks()
+                .FirstDayOfWeek(DayOfWeek.Monday)
+                .OnDays(Day.SATURDAY | Day.SUNDAY)
+                .Ending(new DateTime(2018, 8, 28))
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2018, 2, 24), weekly.Next(new DateTime(2018, 2, 23)));
+            Assert.Equal(new DateTime(2018, 2, 25), weekly.Next(new DateTime(2018, 2, 24)));
+
+            Assert.Equal(new DateTime(2018, 3, 10), weekly.Next(new DateTime(2018, 3, 2)));
+            Assert.Equal(new DateTime(2018, 3, 10), weekly.Next(new DateTime(2018, 3, 3)));
+
+            Assert.Equal(new DateTime(2018, 3, 10), weekly.Next(new DateTime(2018, 3, 9)));
+            Assert.Equal(new DateTime(2018, 3, 11), weekly.Next(new DateTime(2018, 3, 10)));
+            
+            Assert.Null(weekly.Next(new DateTime(2018, 8, 28)));
+        }
+
+
+        [Fact]
+        public void Weekly_Every2Weeks_SunMon()
+        {
+            // Arrange.
+            DateTime startDate = new DateTime(2018, 2, 22);
+
+            IRecurring weekly = Recurs
+                .Starting(startDate)                
+                .Every(2)
+                .Weeks()
+                .FirstDayOfWeek(DayOfWeek.Monday)
+                .OnDays(Day.SUNDAY | Day.MONDAY)
+                .Ending(new DateTime(2018, 8, 28))
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2018, 2, 25), weekly.Next(new DateTime(2018, 2, 24)));
+            Assert.Equal(new DateTime(2018, 3, 5), weekly.Next(new DateTime(2018, 2, 25)));
+
+            Assert.Equal(new DateTime(2018, 3, 5), weekly.Next(new DateTime(2018, 3, 3)));
+            Assert.Equal(new DateTime(2018, 3, 11), weekly.Next(new DateTime(2018, 3, 5)));
+
+            Assert.Equal(new DateTime(2018, 3, 19), weekly.Next(new DateTime(2018, 3, 11)));
+            Assert.Equal(new DateTime(2018, 3, 25), weekly.Next(new DateTime(2018, 3, 20)));
+
+            Assert.Equal(new DateTime(2018, 4, 2), weekly.Next(new DateTime(2018, 4, 1)));
+            Assert.Equal(new DateTime(2018, 4, 8), weekly.Next(new DateTime(2018, 4, 3)));
+
+            Assert.Null(weekly.Next(new DateTime(2018, 8, 28)));
+        }
+
     }
 }

--- a/Dates.Recurring/Builders/WeeksBuilder.cs
+++ b/Dates.Recurring/Builders/WeeksBuilder.cs
@@ -13,6 +13,7 @@ namespace Dates.Recurring.Builders
         private DateTime _starting;
         private DateTime? _ending;
         private Day _days;
+        private DayOfWeek _firstDayOfWeek = DayOfWeek.Sunday;
 
         public WeeksBuilder(int weeks, DateTime starting)
         {
@@ -62,9 +63,15 @@ namespace Dates.Recurring.Builders
             return this;
         }
 
+        public WeeksBuilder FirstDayOfWeek(DayOfWeek day)
+        {
+            _firstDayOfWeek = day;
+            return this;
+        }
+
         public Weekly Build()
         {
-            return new Weekly(_weeks, _starting, _ending, _days);
+            return new Weekly(_weeks, _starting, _ending, _days, _firstDayOfWeek);
         }
     }
 }

--- a/Dates.Recurring/Type/Weekly.cs
+++ b/Dates.Recurring/Type/Weekly.cs
@@ -10,10 +10,26 @@ namespace Dates.Recurring.Type
     public class Weekly : RecurrenceType
     {
         public Day Days { get; set; }
+        public DayOfWeek FirstDayOfWeek { get; set; }
+        private DayOfWeek LastDayOfWeek
+        {
+            get
+            {
+                if (this.FirstDayOfWeek == DayOfWeek.Sunday)
+                {
+                    return DayOfWeek.Saturday;
+                }
+                else
+                {
+                    return this.FirstDayOfWeek - 1;
+                }
+            }
+        }
 
-        public Weekly(int weeks, DateTime starting, DateTime? ending, Day days) : base(weeks, starting, ending)
+        public Weekly(int weeks, DateTime starting, DateTime? ending, Day days, DayOfWeek firstDayOfWeek) : base(weeks, starting, ending)
         {
             Days = days;
+            FirstDayOfWeek = firstDayOfWeek;
         }
 
         public override DateTime? Next(DateTime after)
@@ -27,7 +43,7 @@ namespace Dates.Recurring.Type
 
             while (next.Date <= after.Date || !DayOfWeekMatched(next.DayOfWeek))
             {
-                if (next.DayOfWeek != DayOfWeek.Saturday)
+                if (next.DayOfWeek != LastDayOfWeek)
                 {
                     next = next + 1.Days();
                 }
@@ -37,7 +53,7 @@ namespace Dates.Recurring.Type
                     next = next + X.Weeks();
 
                     // Rewind to the first day of the week.
-                    int delta = DayOfWeek.Sunday - next.DayOfWeek;
+                    int delta = FirstDayOfWeek - next.DayOfWeek;
                     if (delta > 0)
                     {
                         delta -= 7;

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ var weekly = Recurs
     .Starting(new DateTime(2015, 1, 1))
     .Every(1)
     .Weeks()
+	.FirstDayOfWeek(DayOfWeek.Monday)
     .OnDays(Day.TUESDAY | Day.FRIDAY)
     .Ending(new DateTime(2015, 2, 19))
     .Build();


### PR DESCRIPTION
Hi Gavyn,

This is my first attempt at contributing to an open source project (and I'm more of a TFS person than Git), so apologies in advance if I've messed anything up here.

The library has been hugely useful with an Exchange Web Service syncing module I've been adding to a system recently, but I had problems with certain Weekly recurrence patterns due to the calendar I was syncing with using Monday as the first day of the week, rather than Sunday, which Dates.Recurring used by default. This change simply allows users to set the first day of the week they choose. I've added tests and an example in the read me which hopefully illustrate what I'm talking about.

Thanks again for the library, 
Mark