### PR TITLE
fix: remove flags enum attribute

### DIFF
--- a/Dates.Recurring.Tests/Dates.Recurring.Tests.csproj
+++ b/Dates.Recurring.Tests/Dates.Recurring.Tests.csproj
@@ -64,6 +64,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="OrdinalTests.cs" />
     <Compile Include="DailyRecurrenceTests.cs" />
     <Compile Include="MonthlyRecurrenceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Dates.Recurring.Tests/OrdinalTests.cs
+++ b/Dates.Recurring.Tests/OrdinalTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Xunit;
+
+namespace Dates.Recurring.Tests
+{
+    public class OrdinalTests
+    {
+        [Fact]
+        public void Ordinal_Format_Should_Not_Behave_As_Flags_Enum_On_Conversion_To_String()
+        {
+            Assert.Equal("THIRD", (Ordinal.FIRST | Ordinal.SECOND).ToString());
+        }
+
+        [Fact]
+        public void Ordinal_Format_Should_Not_Behave_As_Flags_Enum_On_Conversion_From_String()
+        {
+            Ordinal result;
+            Assert.True(Enum.TryParse("FIRST,SECOND", out result));
+            Assert.Equal(Ordinal.THIRD, result);
+        }
+    }
+}

--- a/Dates.Recurring/Enums/Ordinal.cs
+++ b/Dates.Recurring/Enums/Ordinal.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace Dates.Recurring
 {
-    [Flags]
     public enum Ordinal : int
     {
         [Description("First")]


### PR DESCRIPTION
Hi, I don't think the Ordinal enum should have a Flags attribute on it as the enum values are not powers of two. This PR removes it and adds some unit tests documenting the Format/Parse behaviour.
Thanks.