### PR TITLE
Fixed an issue with same date

### DIFF
--- a/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
@@ -207,6 +207,25 @@ namespace Dates.Recurring.Tests
 
             Assert.Null(monthly.Previous(new DateTime(2018, 1, 31)));
         }
+
+        [Fact]
+        public void Monthly_EveryLastMonth_Ordinal_SameDay()
+        {
+            // Arrange.
+            IRecurring monthly = Recurs
+                .Starting(new DateTime(2018, 12, 25, 11, 00, 00)) // Monday
+                .Every(1)
+                .Months()
+                .OnOrdinalWeek(Ordinal.FOURTH)
+                .OnDay(DayOfWeek.Tuesday)
+                .Ending(new DateTime(2019, 12, 26))
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2018,12,25, 11,00,00 ), monthly.Next(new DateTime(2018, 12, 25, 09, 00 ,00)));
+        }
     }
 }
 

--- a/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
@@ -162,7 +162,7 @@ namespace Dates.Recurring.Tests
             // Assert.
             Assert.Equal(new DateTime(2018, 1, 12), monthly.Next(new DateTime(2017, 1, 1)));
             Assert.Equal(new DateTime(2018, 1, 12), monthly.Next(new DateTime(2018, 1, 1)));
-            Assert.Equal(new DateTime(2018, 4, 13), monthly.Next(new DateTime(2018, 1, 12)));
+            Assert.Equal(new DateTime(2018, 1, 12), monthly.Next(new DateTime(2018, 1, 12)));
             Assert.Equal(new DateTime(2018, 7, 13), monthly.Next(new DateTime(2018, 7, 1)));
 
             Assert.Null(monthly.Next(new DateTime(2020, 2, 1)));
@@ -193,7 +193,7 @@ namespace Dates.Recurring.Tests
             // Assert.
             Assert.Equal(new DateTime(2018, 1, 31), monthly.Next(new DateTime(2017, 1, 1)));
             Assert.Equal(new DateTime(2018, 1, 31), monthly.Next(new DateTime(2018, 1, 1)));
-            Assert.Equal(new DateTime(2018, 2, 28), monthly.Next(new DateTime(2018, 1, 31)));
+            Assert.Equal(new DateTime(2018, 1, 31), monthly.Next(new DateTime(2018, 1, 31)));
             Assert.Equal(new DateTime(2018, 2, 28), monthly.Next(new DateTime(2018, 2, 1)));
             Assert.Equal(new DateTime(2018, 4, 25), monthly.Next(new DateTime(2018, 4, 1)));
 
@@ -213,18 +213,17 @@ namespace Dates.Recurring.Tests
         {
             // Arrange.
             IRecurring monthly = Recurs
-                .Starting(new DateTime(2018, 12, 25, 11, 00, 00)) // Tuesday
+                .Starting(new DateTime(2019,04,30,13,00,00)) // Tuesday
                 .Every(1)
                 .Months()
-                .OnOrdinalWeek(Ordinal.FOURTH)
-                .OnDay(DayOfWeek.Tuesday)
-                .Ending(new DateTime(2019, 12, 26))
+                .OnOrdinalWeek(Ordinal.LAST)
+                .OnDay(DayOfWeek.Monday)
                 .Build();
 
             // Act.
 
             // Assert.
-            Assert.Equal(new DateTime(2018,12,25, 11,00,00 ), monthly.Next(new DateTime(2018, 12, 25, 09, 00 ,00)));
+            Assert.Equal(new DateTime(2019,05,27,13,00,00), monthly.Next(new DateTime(2019,05,27,09,00,00)));
         }
     }
 }

--- a/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
@@ -213,7 +213,7 @@ namespace Dates.Recurring.Tests
         {
             // Arrange.
             IRecurring monthly = Recurs
-                .Starting(new DateTime(2018, 12, 25, 11, 00, 00)) // Monday
+                .Starting(new DateTime(2018, 12, 25, 11, 00, 00)) // Tuesday
                 .Every(1)
                 .Months()
                 .OnOrdinalWeek(Ordinal.FOURTH)

--- a/Dates.Recurring.Tests/YearlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/YearlyRecurrenceTests.cs
@@ -11,7 +11,7 @@ namespace Dates.Recurring.Tests
         {
             // Arrange.
             IRecurring yearly = Recurs
-                .Starting(new DateTime(2015, 1, 1))
+                .Starting(new DateTime(2015, 1, 1, 11, 00 ,00))
                 .Every(1)
                 .Years()
                 .OnDay(24)
@@ -22,43 +22,45 @@ namespace Dates.Recurring.Tests
             // Act.
 
             // Assert.
-            Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2014, 1, 1)));
-            Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 1)));
-            Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 23)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 1, 24)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 1, 25)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 2, 1)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 2, 23)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 2, 24)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 3, 24)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 4, 24)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 5, 24)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 6, 24)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 7, 24)));
-            Assert.Equal(new DateTime(2016, 1, 24), yearly.Next(new DateTime(2015, 8, 24)));
-            Assert.Equal(new DateTime(2016, 2, 24), yearly.Next(new DateTime(2016, 1, 24)));
+            Assert.Equal(new DateTime(2015, 1, 24,11,00,00), yearly.Next(new DateTime(2014, 1, 1)));
+            Assert.Equal(new DateTime(2015, 1, 24,11,00,00), yearly.Next(new DateTime(2015, 1, 1)));
+            Assert.Equal(new DateTime(2015, 1, 24,11,00,00), yearly.Next(new DateTime(2015, 1, 23)));
+            Assert.Equal(new DateTime(2015, 1, 24,11,00,00), yearly.Next(new DateTime(2015, 1, 24)));
+            Assert.Equal(new DateTime(2015, 2, 24,11,00,00), yearly.Next(new DateTime(2015, 1, 25)));
+            Assert.Equal(new DateTime(2015, 2, 24,11,00,00), yearly.Next(new DateTime(2015, 2, 1)));
+            Assert.Equal(new DateTime(2015, 2, 24,11,00,00), yearly.Next(new DateTime(2015, 2, 23)));
 
-            Assert.Null(yearly.Next(new DateTime(2020, 1, 1)));
+            Assert.Equal(new DateTime(2015, 2, 24,11,00,00), yearly.Next(new DateTime(2015, 2, 24)));
 
-            Assert.Equal(new DateTime(2015, 1, 24), yearly.Previous(new DateTime(2015, 1, 25)));
-            Assert.Equal(new DateTime(2015, 1, 24), yearly.Previous(new DateTime(2015, 2, 23)));
-            Assert.Equal(new DateTime(2015, 1, 24), yearly.Previous(new DateTime(2015, 2, 24)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Previous(new DateTime(2015, 2, 25)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Previous(new DateTime(2015, 3, 25)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Previous(new DateTime(2015, 4, 25)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Previous(new DateTime(2015, 7, 25)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Previous(new DateTime(2015, 8, 25)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Previous(new DateTime(2015, 9, 25)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Previous(new DateTime(2015, 10, 25)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Previous(new DateTime(2015, 12, 25)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Previous(new DateTime(2016, 1, 1)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Previous(new DateTime(2016, 1, 24)));
-            Assert.Equal(new DateTime(2016, 1, 24), yearly.Previous(new DateTime(2016, 1, 25)));
-            Assert.Equal(new DateTime(2016, 2, 24), yearly.Previous(new DateTime(2016, 2, 25)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Next(new DateTime(2015, 3, 24)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Next(new DateTime(2015, 4, 24)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Next(new DateTime(2015, 5, 24)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Next(new DateTime(2015, 6, 24)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Next(new DateTime(2015, 7, 24)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Next(new DateTime(2015, 8, 24)));
+            Assert.Equal(new DateTime(2016, 1, 24,11,00,00), yearly.Next(new DateTime(2016, 1, 24)));
 
-            Assert.Null(yearly.Previous(new DateTime(2015, 1, 24)));
-            Assert.Null(yearly.Previous(new DateTime(2015, 1, 1)));
-            Assert.Null(yearly.Previous(new DateTime(2014, 1, 24)));
+            Assert.Null(yearly.Next(new DateTime(2020, 1, 1,11,00,00)));
+
+            Assert.Equal(new DateTime(2015, 1, 24,11,00,00), yearly.Previous(new DateTime(2015, 1, 25)));
+            Assert.Equal(new DateTime(2015, 1, 24,11,00,00), yearly.Previous(new DateTime(2015, 2, 23)));
+            Assert.Equal(new DateTime(2015, 1, 24,11,00,00), yearly.Previous(new DateTime(2015, 2, 24)));
+            Assert.Equal(new DateTime(2015, 2, 24,11,00,00), yearly.Previous(new DateTime(2015, 2, 25)));
+            Assert.Equal(new DateTime(2015, 2, 24,11,00,00), yearly.Previous(new DateTime(2015, 3, 25)));
+            Assert.Equal(new DateTime(2015, 2, 24,11,00,00), yearly.Previous(new DateTime(2015, 4, 25)));
+            Assert.Equal(new DateTime(2015, 2, 24,11,00,00), yearly.Previous(new DateTime(2015, 7, 25)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Previous(new DateTime(2015, 8, 25)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Previous(new DateTime(2015, 9, 25)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Previous(new DateTime(2015, 10, 25)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Previous(new DateTime(2015, 12, 25)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Previous(new DateTime(2016, 1, 1)));
+            Assert.Equal(new DateTime(2015, 8, 24,11,00,00), yearly.Previous(new DateTime(2016, 1, 24)));
+            Assert.Equal(new DateTime(2016, 1, 24,11,00,00), yearly.Previous(new DateTime(2016, 1, 25)));
+            Assert.Equal(new DateTime(2016, 2, 24,11,00,00), yearly.Previous(new DateTime(2016, 2, 25)));
+
+            Assert.Null(yearly.Previous(new DateTime(2015, 1, 24,11,00,00)));
+            Assert.Null(yearly.Previous(new DateTime(2015, 1, 1,11,00,00)));
+            Assert.Null(yearly.Previous(new DateTime(2014, 1, 24,11,00,00)));
         }
 
         [Fact]
@@ -80,19 +82,19 @@ namespace Dates.Recurring.Tests
             Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2014, 1, 1)));
             Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 1)));
             Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 23)));
-            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 1, 24)));
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 24)));
             Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 1, 25)));
             Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 2, 1)));
             Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 2, 23)));
-            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 2, 24)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 2, 24)));
             Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 3, 24)));
             Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 4, 24)));
             Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 5, 24)));
             Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 6, 24)));
             Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 7, 24)));
-            Assert.Equal(new DateTime(2018, 1, 24), yearly.Next(new DateTime(2015, 8, 24)));
-            Assert.Equal(new DateTime(2018, 2, 24), yearly.Next(new DateTime(2018, 1, 24)));
-            Assert.Equal(new DateTime(2018, 8, 24), yearly.Next(new DateTime(2018, 2, 24)));
+            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 8, 24)));
+            Assert.Equal(new DateTime(2018, 1, 24), yearly.Next(new DateTime(2018, 1, 24)));
+            Assert.Equal(new DateTime(2018, 2, 24), yearly.Next(new DateTime(2018, 2, 24)));
             Assert.Equal(new DateTime(2018, 8, 24), yearly.Next(new DateTime(2018, 6, 11)));
 
             Assert.Null(yearly.Next(new DateTime(2020, 1, 1)));
@@ -136,9 +138,9 @@ namespace Dates.Recurring.Tests
             // Assert.
             Assert.Equal(new DateTime(2015, 1, 31), yearly.Next(new DateTime(2014, 1, 1)));
             Assert.Equal(new DateTime(2015, 1, 31), yearly.Next(new DateTime(2015, 1, 6)));
-            Assert.Equal(new DateTime(2015, 2, 28), yearly.Next(new DateTime(2015, 1, 31)));
+            Assert.Equal(new DateTime(2015, 1, 31), yearly.Next(new DateTime(2015, 1, 31)));
             Assert.Equal(new DateTime(2015, 2, 28), yearly.Next(new DateTime(2015, 2, 27)));
-            Assert.Equal(new DateTime(2015, 8, 31), yearly.Next(new DateTime(2015, 2, 28)));
+            Assert.Equal(new DateTime(2015, 2, 28), yearly.Next(new DateTime(2015, 2, 28)));
 
             Assert.Null(yearly.Next(new DateTime(2020, 1, 1)));
 
@@ -172,12 +174,12 @@ namespace Dates.Recurring.Tests
             Assert.Equal(new DateTime(2015, 3, 24), yearly.Next(new DateTime(2014, 1, 1)));
             Assert.Equal(new DateTime(2015, 3, 24), yearly.Next(new DateTime(2015, 1, 1)));
             Assert.Equal(new DateTime(2015, 3, 24), yearly.Next(new DateTime(2015, 1, 23)));
-            Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 3, 24)));
+            Assert.Equal(new DateTime(2015, 3, 24), yearly.Next(new DateTime(2015, 3, 24)));
             Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 3, 25)));
             Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 10, 1)));
             Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 10, 23)));
             Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2015, 10, 24)));
-            Assert.Equal(new DateTime(2017, 3, 24), yearly.Next(new DateTime(2016, 3, 24)));
+            Assert.Equal(new DateTime(2016, 3, 24), yearly.Next(new DateTime(2016, 3, 24)));
             Assert.Equal(new DateTime(2017, 3, 24), yearly.Next(new DateTime(2016, 4, 24)));
 
             Assert.Null(yearly.Next(new DateTime(2020, 1, 1)));
@@ -214,7 +216,7 @@ namespace Dates.Recurring.Tests
             // Assert.
             Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2014, 1, 1)));
             Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2018, 1, 1)));
-            Assert.Equal(new DateTime(2019, 1, 17), yearly.Next(new DateTime(2018, 1, 18)));
+            Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2018, 1, 18)));
             Assert.Equal(new DateTime(2020, 1, 16), yearly.Next(new DateTime(2019, 2, 18)));
 
             Assert.Null(yearly.Next(new DateTime(2030, 1, 1)));
@@ -247,8 +249,9 @@ namespace Dates.Recurring.Tests
 
             // Assert.
             Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2014, 1, 1)));
+            Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2014, 1, 1)));
             Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2018, 1, 1)));
-            Assert.Equal(new DateTime(2021, 1, 21), yearly.Next(new DateTime(2018, 1, 18)));
+            Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2018, 1, 18)));
             Assert.Equal(new DateTime(2024, 1, 18), yearly.Next(new DateTime(2021, 2, 18)));
 
             Assert.Null(yearly.Next(new DateTime(2030, 1, 1)));
@@ -282,8 +285,8 @@ namespace Dates.Recurring.Tests
             // Assert.
             Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2014, 1, 1)));
             Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2018, 1, 1)));
-            Assert.Equal(new DateTime(2018, 4, 19), yearly.Next(new DateTime(2018, 1, 18)));
-            Assert.Equal(new DateTime(2019, 1, 17), yearly.Next(new DateTime(2018, 4, 19)));
+            Assert.Equal(new DateTime(2018, 1, 18), yearly.Next(new DateTime(2018, 1, 18)));
+            Assert.Equal(new DateTime(2018, 4,19), yearly.Next(new DateTime(2018, 4, 19)));
 
             Assert.Null(yearly.Next(new DateTime(2030, 1, 1)));
 
@@ -294,6 +297,30 @@ namespace Dates.Recurring.Tests
 
             Assert.Null(yearly.Previous(new DateTime(2018, 1, 18)));
         }
+
+        [Fact]
+        public void Yearly_EveryYear_Ordinal_Today()
+        {
+            // Arrange.
+            var startDate = new DateTime(2019, 1, 1,12,00,00);
+
+            IRecurring yearly = Recurs
+                .Starting(startDate)
+                .Every(1)
+                .Years()
+                .OnOrdinalWeek(Ordinal.FIRST)
+                .OnDay(DayOfWeek.Monday)
+                .OnMonths(Month.JANUARY)
+                .Ending(new DateTime(2030, 1, 1))
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2020,01,6,12,00,00), yearly.Next(new DateTime(2020,01,06,08,00,00)));
+            
+        }
+
     }
 }
 

--- a/Dates.Recurring/Type/Monthly.cs
+++ b/Dates.Recurring/Type/Monthly.cs
@@ -55,7 +55,7 @@ namespace Dates.Recurring.Type
 
             var targetDay = OrdinalTargetDay(next.Month, next.Year);
 
-            while (next.Date <= after.Date || !DayOfMonthMatched(targetDay, next))
+            while (next.Date < after.Date || !DayOfMonthMatched(targetDay, next))
             {
                 var candidate = GetNextOrdinalDayCandidate(next, targetDay);
 

--- a/Dates.Recurring/Type/Monthly.cs
+++ b/Dates.Recurring/Type/Monthly.cs
@@ -48,7 +48,7 @@ namespace Dates.Recurring.Type
         {
             var next = Starting;
 
-            if (after.Date < Starting.Date)
+            if (after.Date <= Starting.Date)
             {
                 after = Starting - 1.Days();
             }

--- a/Dates.Recurring/Type/Yearly.cs
+++ b/Dates.Recurring/Type/Yearly.cs
@@ -61,7 +61,7 @@ namespace Dates.Recurring.Type
 
             var targetDay = OrdinalTargetDay(next.Month, next.Year);
 
-            while (next.Date <= after.Date || !MonthMatched(next) || !DayOfMonthMatched(targetDay, next))
+            while (next.Date < after.Date || !MonthMatched(next) || !DayOfMonthMatched(targetDay, next))
             {
                 var candidate = GetNextOrdinalCandidate(next, targetDay);
 
@@ -123,7 +123,7 @@ namespace Dates.Recurring.Type
                 after = Starting - 1.Days();
             }
 
-            while (next.Date <= after.Date || !MonthMatched(next) || !DayOfMonthMatched(DayOfMonth.Value, next))
+            while (next.Date < after.Date || !MonthMatched(next) || !DayOfMonthMatched(DayOfMonth.Value, next))
             {
                 next = GetNextSpecificDayCandidate(next);
             }


### PR DESCRIPTION
Fixed the issue where it's monthly and it's scheduled on the same day but before the next fire time.

See unit test for reproduction.

This is ultimately an issue that the code does not take the Time of day into account