### PR TITLE
Added Ending After Method to Builders

### DIFF
--- a/Dates.Recurring.Tests/DailyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/DailyRecurrenceTests.cs
@@ -112,5 +112,37 @@ namespace Dates.Recurring.Tests
             Assert.Equal(new DateTime(2015, 1, 14), daily.Previous(new DateTime(2015, 1, 15)));
         }
 
+        [Fact]
+        public void Daily_EveryDay_EndingAfter()
+        {
+            // Arrange.
+            IRecurring daily = Recurs
+                .Starting(new DateTime(2015, 1, 1))
+                .Every(1)
+                .Days()
+                .EndingAfter(5)
+                .Build();
+            
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2015, 1, 2), daily.Next(new DateTime(2015, 1, 1)));
+            Assert.Equal(new DateTime(2015, 1, 3), daily.Next(new DateTime(2015, 1, 2)));
+            Assert.Equal(new DateTime(2015, 1, 4), daily.Next(new DateTime(2015, 1, 3)));
+            Assert.Equal(new DateTime(2015, 1, 5), daily.Next(new DateTime(2015, 1, 4)));
+            Assert.Equal(new DateTime(2015, 1, 6), daily.Next(new DateTime(2015, 1, 5)));
+
+            Assert.Null(daily.Next(new DateTime(2015, 1, 6)));
+
+            Assert.Equal(new DateTime(2015, 1, 1), daily.Previous(new DateTime(2015, 1, 2)));
+            Assert.Equal(new DateTime(2015, 1, 2), daily.Previous(new DateTime(2015, 1, 3)));
+            Assert.Equal(new DateTime(2015, 1, 3), daily.Previous(new DateTime(2015, 1, 4)));
+            Assert.Equal(new DateTime(2015, 1, 4), daily.Previous(new DateTime(2015, 1, 5)));
+            Assert.Equal(new DateTime(2015, 1, 5), daily.Previous(new DateTime(2015, 1, 6)));
+            Assert.Equal(new DateTime(2015, 1, 5), daily.Previous(new DateTime(2015, 2, 6)));
+
+            Assert.Null(daily.Previous(new DateTime(2015, 1, 1)));
+        }
+
     }
 }

--- a/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/MonthlyRecurrenceTests.cs
@@ -207,6 +207,83 @@ namespace Dates.Recurring.Tests
 
             Assert.Null(monthly.Previous(new DateTime(2018, 1, 31)));
         }
+
+        [Fact]
+        public void Monthly_EveryMonth_OnDay_EndingAfter()
+        {
+            // Arrange.
+            IRecurring monthly = Recurs
+                .Starting(new DateTime(2015, 1, 1))
+                .Every(1)
+                .Months()
+                .OnDay(24)
+                .EndingAfter(5)
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2015, 1, 24), monthly.Next(new DateTime(2015, 1, 1)));
+            Assert.Equal(new DateTime(2015, 2, 24), monthly.Next(new DateTime(2015, 2, 1)));
+            Assert.Equal(new DateTime(2015, 3, 24), monthly.Next(new DateTime(2015, 3, 1)));
+            Assert.Equal(new DateTime(2015, 4, 24), monthly.Next(new DateTime(2015, 4, 1)));
+            Assert.Equal(new DateTime(2015, 5, 24), monthly.Next(new DateTime(2015, 5, 1)));
+
+            Assert.Null(monthly.Next(new DateTime(2015, 6, 1)));
+
+            Assert.Equal(new DateTime(2015, 1, 24), monthly.Previous(new DateTime(2015, 2, 1)));
+            Assert.Equal(new DateTime(2015, 2, 24), monthly.Previous(new DateTime(2015, 3, 1)));
+            Assert.Equal(new DateTime(2015, 3, 24), monthly.Previous(new DateTime(2015, 4, 1)));
+            Assert.Equal(new DateTime(2015, 4, 24), monthly.Previous(new DateTime(2015, 5, 1)));
+            Assert.Equal(new DateTime(2015, 5, 24), monthly.Previous(new DateTime(2015, 6, 1)));
+            Assert.Equal(new DateTime(2015, 5, 24), monthly.Previous(new DateTime(2016, 6, 1)));
+            Assert.Equal(new DateTime(2015, 5, 24), monthly.Previous(new DateTime(2017, 8, 1)));
+            Assert.Equal(new DateTime(2015, 5, 24), monthly.Previous(new DateTime(2020, 10, 13)));
+
+            Assert.Null(monthly.Previous(new DateTime(2015, 1, 1)));
+            Assert.Null(monthly.Previous(new DateTime(2014, 6, 1)));
+        }
+
+        [Fact]
+        public void Monthly_EveryMonth_Ordinal_LastWeek_EndingAfter()
+        {
+            // Arrange.
+            IRecurring monthly = Recurs
+                .Starting(new DateTime(2018, 1, 1)) // Monday
+                .Every(1)
+                .Months()
+                .OnOrdinalWeek(Ordinal.LAST)
+                .OnDay(DayOfWeek.Wednesday)
+                .EndingAfter(5)
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2018, 1, 31), monthly.Next(new DateTime(2017, 1, 1)));
+            Assert.Equal(new DateTime(2018, 1, 31), monthly.Next(new DateTime(2018, 1, 1)));
+            Assert.Equal(new DateTime(2018, 2, 28), monthly.Next(new DateTime(2018, 1, 31)));
+            Assert.Equal(new DateTime(2018, 2, 28), monthly.Next(new DateTime(2018, 2, 1)));
+            Assert.Equal(new DateTime(2018, 3, 28), monthly.Next(new DateTime(2018, 3, 1)));
+            Assert.Equal(new DateTime(2018, 4, 25), monthly.Next(new DateTime(2018, 4, 1)));
+            Assert.Equal(new DateTime(2018, 5, 30), monthly.Next(new DateTime(2018, 5, 1)));
+            
+            Assert.Null(monthly.Next(new DateTime(2018, 5, 31)));
+            Assert.Null(monthly.Next(new DateTime(2018, 6, 1)));
+            Assert.Null(monthly.Next(new DateTime(2020, 2, 1)));
+
+            Assert.Equal(new DateTime(2018, 1, 31), monthly.Previous(new DateTime(2018, 2, 1)));
+            Assert.Equal(new DateTime(2018, 2, 28), monthly.Previous(new DateTime(2018, 3, 1)));
+            Assert.Equal(new DateTime(2018, 3, 28), monthly.Previous(new DateTime(2018, 4, 1)));
+            Assert.Equal(new DateTime(2018, 4, 25), monthly.Previous(new DateTime(2018, 5, 1)));
+            Assert.Equal(new DateTime(2018, 5, 30), monthly.Previous(new DateTime(2018, 6, 1)));
+            Assert.Equal(new DateTime(2018, 5, 30), monthly.Previous(new DateTime(2019, 6, 1)));
+            Assert.Equal(new DateTime(2018, 5, 30), monthly.Previous(new DateTime(2020, 8, 1)));
+            Assert.Equal(new DateTime(2018, 5, 30), monthly.Previous(new DateTime(2021, 10, 13)));
+
+            Assert.Null(monthly.Previous(new DateTime(2018, 1, 1)));
+            Assert.Null(monthly.Previous(new DateTime(2017, 6, 1)));
+        }
     }
 }
 

--- a/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/WeeklyRecurrenceTests.cs
@@ -193,5 +193,40 @@ namespace Dates.Recurring.Tests
 
             Assert.Null(weekly.Previous(new DateTime(2018, 2, 25)));
         }
+
+        [Fact]
+        public void Weekly_EveryWeek_EndingAfter()
+        {
+            // Arrange.
+            IRecurring weekly = Recurs
+                .Starting(new DateTime(2015, 1, 1)) // Thursday
+                .Every(1)
+                .Weeks()
+                .OnDays(Day.TUESDAY | Day.FRIDAY)
+                .EndingAfter(5)
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2015, 1, 2), weekly.Next(new DateTime(2014, 1, 1)));
+            Assert.Equal(new DateTime(2015, 1, 6), weekly.Next(new DateTime(2015, 1, 2)));
+            Assert.Equal(new DateTime(2015, 1, 9), weekly.Next(new DateTime(2015, 1, 6)));
+            Assert.Equal(new DateTime(2015, 1, 13), weekly.Next(new DateTime(2015, 1, 9)));
+            Assert.Equal(new DateTime(2015, 1, 16), weekly.Next(new DateTime(2015, 1, 13)));
+
+            Assert.Null(weekly.Next(new DateTime(2015, 1, 20)));
+
+            Assert.Equal(new DateTime(2015, 1, 2), weekly.Previous(new DateTime(2015, 1, 6)));
+            Assert.Equal(new DateTime(2015, 1, 6), weekly.Previous(new DateTime(2015, 1, 9)));
+            Assert.Equal(new DateTime(2015, 1, 9), weekly.Previous(new DateTime(2015, 1, 13)));
+            Assert.Equal(new DateTime(2015, 1, 13), weekly.Previous(new DateTime(2015, 1, 16)));
+            Assert.Equal(new DateTime(2015, 1, 16), weekly.Previous(new DateTime(2015, 3, 16)));
+            Assert.Equal(new DateTime(2015, 1, 16), weekly.Previous(new DateTime(2019, 12, 16)));
+            Assert.Equal(new DateTime(2015, 1, 16), weekly.Previous(new DateTime(2020, 3, 16)));
+
+            Assert.Null(weekly.Previous(new DateTime(2014, 1, 20)));
+            Assert.Null(weekly.Previous(new DateTime(2015, 1, 2)));
+        }
     }
 }

--- a/Dates.Recurring.Tests/YearlyRecurrenceTests.cs
+++ b/Dates.Recurring.Tests/YearlyRecurrenceTests.cs
@@ -294,6 +294,81 @@ namespace Dates.Recurring.Tests
 
             Assert.Null(yearly.Previous(new DateTime(2018, 1, 18)));
         }
+
+        [Fact]
+        public void Yearly_EveryYear_OnDay_OnMonths_EndingAfter()
+        {
+            // Arrange.
+            IRecurring yearly = Recurs
+                .Starting(new DateTime(2015, 1, 1))
+                .Every(1)
+                .Years()
+                .OnDay(24)
+                .OnMonths(Month.JANUARY | Month.FEBRUARY | Month.AUGUST)
+                .EndingAfter(5)
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 1)));
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 23)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 1, 24)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 1, 25)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 2, 1)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 2, 23)));
+            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 2, 24)));
+            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 6, 24)));
+            Assert.Equal(new DateTime(2015, 8, 24), yearly.Next(new DateTime(2015, 7, 24)));
+            Assert.Equal(new DateTime(2016, 1, 24), yearly.Next(new DateTime(2015, 8, 24)));
+            Assert.Equal(new DateTime(2016, 2, 24), yearly.Next(new DateTime(2016, 1, 24)));
+            
+            Assert.Null(yearly.Next(new DateTime(2016, 2, 25)));
+            Assert.Null(yearly.Next(new DateTime(2017, 1, 25)));
+            Assert.Null(yearly.Next(new DateTime(2020, 1, 1)));
+
+
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Previous(new DateTime(2015, 1, 25)));
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Previous(new DateTime(2015, 2, 1)));
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Previous(new DateTime(2015, 2, 23)));
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Previous(new DateTime(2015, 2, 24)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Previous(new DateTime(2015, 6, 24)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Previous(new DateTime(2015, 7, 24)));
+            Assert.Equal(new DateTime(2016, 2, 24), yearly.Previous(new DateTime(2017, 8, 24)));
+            Assert.Equal(new DateTime(2016, 2, 24), yearly.Previous(new DateTime(2018, 1, 24)));
+            
+            Assert.Null(yearly.Previous(new DateTime(2015, 1, 22)));
+            Assert.Null(yearly.Previous(new DateTime(2014, 1, 25)));
+            Assert.Null(yearly.Previous(new DateTime(2014, 1, 1)));
+        }
+
+        [Fact]
+        public void Yearly_EveryYear_EveryThirdYear_EndingAfter()
+        {
+            // Arrange.
+            IRecurring yearly = Recurs
+                .Starting(new DateTime(2015, 1, 1))
+                .Every(3)
+                .Years()
+                .OnDay(24)
+                .OnMonths(Month.JANUARY | Month.FEBRUARY | Month.AUGUST)
+                .EndingAfter(5)
+                .Build();
+
+            // Act.
+
+            // Assert.
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 1)));
+            Assert.Equal(new DateTime(2015, 1, 24), yearly.Next(new DateTime(2015, 1, 23)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 1, 24)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 1, 25)));
+            Assert.Equal(new DateTime(2015, 2, 24), yearly.Next(new DateTime(2015, 2, 1)));
+            Assert.Equal(new DateTime(2018, 2, 24), yearly.Next(new DateTime(2018, 2, 23)));
+            
+            Assert.Null(yearly.Next(new DateTime(2018, 2, 24)));
+            Assert.Null(yearly.Next(new DateTime(2019, 1, 25)));
+            Assert.Null(yearly.Next(new DateTime(2020, 1, 1)));
+        }
     }
 }
 

--- a/Dates.Recurring/Builders/DaysBuilder.cs
+++ b/Dates.Recurring/Builders/DaysBuilder.cs
@@ -8,6 +8,7 @@ namespace Dates.Recurring.Builders
         private int _days;
         private DateTime _starting;
         private DateTime? _ending;
+        private int? _endingAfter;
         private Day _includeDays = Day.SUNDAY | Day.MONDAY | Day.TUESDAY | Day.WEDNESDAY | Day.THURSDAY | Day.FRIDAY | Day.SATURDAY;
 
         public DaysBuilder(int days, DateTime starting)
@@ -22,6 +23,12 @@ namespace Dates.Recurring.Builders
             return this;
         }
 
+        public DaysBuilder EndingAfter(int endingAfter)
+        {
+            _endingAfter = endingAfter;
+            return this;
+        }
+
         public DaysBuilder Including(Day includeDays)
         {
             _includeDays = includeDays;
@@ -30,7 +37,7 @@ namespace Dates.Recurring.Builders
 
         public Daily Build()
         {
-            return new Daily(_days, _includeDays, _starting, _ending);
+            return new Daily(_days, _includeDays, _starting, _ending, _endingAfter);
         }
     }
 }

--- a/Dates.Recurring/Builders/MonthsBuilder.cs
+++ b/Dates.Recurring/Builders/MonthsBuilder.cs
@@ -11,6 +11,7 @@ namespace Dates.Recurring.Builders
         private DayOfWeek? _dayOfWeek;
         private DateTime _starting;
         private DateTime? _ending;
+        private int? _endingAfter;
 
         public MonthsBuilder(int skipMonths, DateTime starting)
         {
@@ -21,6 +22,12 @@ namespace Dates.Recurring.Builders
         public MonthsBuilder Ending(DateTime ending)
         {
             _ending = ending;
+            return this;
+        }
+
+        public MonthsBuilder EndingAfter(int endingAfter)
+        {
+            _endingAfter = endingAfter;
             return this;
         }
 
@@ -46,9 +53,9 @@ namespace Dates.Recurring.Builders
         {
             if (_dayOfMonth != null)
             {
-                return new Monthly(_skipMonths, _dayOfMonth, _starting, _ending);
+                return new Monthly(_skipMonths, _dayOfMonth, _starting, _ending, _endingAfter);
             }
-            return new Monthly(_skipMonths, _ordinalWeek, _dayOfWeek, _starting, _ending);
+            return new Monthly(_skipMonths, _ordinalWeek, _dayOfWeek, _starting, _ending, _endingAfter);
         }
     }
 }

--- a/Dates.Recurring/Builders/WeeksBuilder.cs
+++ b/Dates.Recurring/Builders/WeeksBuilder.cs
@@ -8,6 +8,7 @@ namespace Dates.Recurring.Builders
         private int _weeks;
         private DateTime _starting;
         private DateTime? _ending;
+        private int? _endingAfter;
         private Day _days;
         private DayOfWeek _firstDayOfWeek = DayOfWeek.Sunday;
 
@@ -21,6 +22,12 @@ namespace Dates.Recurring.Builders
         public WeeksBuilder Ending(DateTime ending)
         {
             _ending = ending;
+            return this;
+        }
+
+        public WeeksBuilder EndingAfter(int endingAfter)
+        {
+            _endingAfter = endingAfter;
             return this;
         }
 
@@ -67,7 +74,7 @@ namespace Dates.Recurring.Builders
 
         public Weekly Build()
         {
-            return new Weekly(_weeks, _starting, _ending, _days, _firstDayOfWeek);
+            return new Weekly(_weeks, _starting, _ending, _endingAfter, _days, _firstDayOfWeek);
         }
     }
 }

--- a/Dates.Recurring/Builders/YearsBuilder.cs
+++ b/Dates.Recurring/Builders/YearsBuilder.cs
@@ -12,6 +12,7 @@ namespace Dates.Recurring.Builders
         private DayOfWeek? _dayOfWeek;
         private DateTime _starting;
         private DateTime? _ending;
+        private int? _endingAfter;
 
         public YearsBuilder(int skipYears, DateTime starting)
         {
@@ -22,6 +23,12 @@ namespace Dates.Recurring.Builders
         public YearsBuilder Ending(DateTime ending)
         {
             _ending = ending;
+            return this;
+        }
+
+        public YearsBuilder EndingAfter(int endingAfter)
+        {
+            _endingAfter = endingAfter;
             return this;
         }
 
@@ -97,9 +104,9 @@ namespace Dates.Recurring.Builders
         {
             if (_dayOfMonth.HasValue)
             {
-                return new Yearly(_skipYears, _dayOfMonth, _month, _starting, _ending);
+                return new Yearly(_skipYears, _dayOfMonth, _month, _starting, _ending, _endingAfter);
             }
-            return new Yearly(_skipYears, _ordinalWeek, _dayOfWeek, _month, _starting, _ending);
+            return new Yearly(_skipYears, _ordinalWeek, _dayOfWeek, _month, _starting, _ending, _endingAfter);
         }
     }
 }

--- a/Dates.Recurring/Type/Daily.cs
+++ b/Dates.Recurring/Type/Daily.cs
@@ -7,7 +7,7 @@ namespace Dates.Recurring.Type
     {
         public Day IncludeDays { get; set; } 
 
-        public Daily(int days, Day includeDays, DateTime starting, DateTime? ending) : base(days, starting, ending)
+        public Daily(int days, Day includeDays, DateTime starting, DateTime? ending, int? endingAfter) : base(days, starting, ending, endingAfter)
         {
             IncludeDays = includeDays;
         }
@@ -15,6 +15,7 @@ namespace Dates.Recurring.Type
         public override DateTime? Next(DateTime after)
         {
             var next = Starting;
+            int iterations = 0;
 
             if (after.Date < Starting.Date)
             {
@@ -24,6 +25,7 @@ namespace Dates.Recurring.Type
             while ((next.Ticks - after.Ticks) <= TimeSpan.TicksPerSecond)
             {
                 next = MoveXDaysForward(next);
+                iterations++;
             }
 
             if (Ending.HasValue && next.Date > Ending.Value.Date)
@@ -31,11 +33,17 @@ namespace Dates.Recurring.Type
                 return null;
             }
 
+            if (EndingAfter.HasValue && iterations > EndingAfter)
+            {
+                return null;
+            }
+            
             return next;
         }
 
         public override DateTime? Previous(DateTime before)
         {
+            int iterations = 0;
             if (before.Date <= Starting.Date)
             {
                 return null;
@@ -51,8 +59,14 @@ namespace Dates.Recurring.Type
 
             while (next.Ticks < before.Ticks)
             {
+                if (EndingAfter.HasValue && iterations >= EndingAfter)
+                {
+                    break;
+                }
+
                 last = next;
                 next = MoveXDaysForward(next);
+                iterations ++;
             }
 
             return last.Value;

--- a/Dates.Recurring/Type/RecurrenceType.cs
+++ b/Dates.Recurring/Type/RecurrenceType.cs
@@ -7,12 +7,14 @@ namespace Dates.Recurring.Type
         protected int X { get; set; }
         protected DateTime Starting { get; set; }
         protected DateTime? Ending { get; set; }
+        protected int? EndingAfter { get; set; }
 
-        public RecurrenceType(int x, DateTime starting, DateTime? ending = null)
+        public RecurrenceType(int x, DateTime starting, DateTime? ending = null, int? endingAfter = null)
         {
             X = x;
             Starting = starting;
             Ending = ending;
+            EndingAfter = endingAfter;
         }
 
         public abstract DateTime? Next(DateTime after);


### PR DESCRIPTION
Hey @nikkilocke, I needed a way to specify after a certain number of iterations in a recurrence to return a null date, showing that the recurrence is over.  I added EndingAfter method to the builders that take in an int which specifies the number of times the user intends for the recurrence to happen.

I'm using your library to create schedules with parameters similar to Outlook or Google Calendar, where one of the options is to select is a "ends after" so many occurrences of the event. This seemed like something that might be useful to others, which is why I'm submitting this pull request. Let me know what you think.

Thanks.